### PR TITLE
fix failing 'npm run build'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "npm-run-all": "^4.1.5",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"


### PR DESCRIPTION
This PR fixes an issue with the golang version of the quickstart example https://docs.dagger.io/quickstart/daggerize/#get-the-example-application when executing `npm run build`. Didn't test the other SDKs, however

```
Stderr:
sh: 1: run-p: Permission denied
```